### PR TITLE
Remove isAstDirty check in generate method

### DIFF
--- a/MarkdownAsset.js
+++ b/MarkdownAsset.js
@@ -20,7 +20,7 @@ module.exports = class MarkdownAsset extends HTMLAsset {
     }
     
     generate() {
-        let html = this.isAstDirty ? render(this.ast) : this.contents;
+        let html = render(this.ast);
         return {
             js: `module.exports=\`${html}\``
         };


### PR DESCRIPTION
When looking in HTMLAsset from Parcel source, the AST is considered "dirty" if it contains any references to other modules (which Parcel also wants to bundle).

When using this library, I can only get it to work if I put an image or something into the Markdown file. Otherwise the default export is not actually compiled to HTML. So I figured you could just *not* perform this check.