### PR TITLE
support latest release of parcel bundler

### DIFF
--- a/MarkdownAsset.js
+++ b/MarkdownAsset.js
@@ -4,18 +4,11 @@ const marked = require('marked');
 module.exports = class MarkdownAsset extends HTMLAsset {
     constructor(name, pkg, options) {
         super(name, pkg, options);
-        this.type = 'js';
         this.markedOptions = pkg.marked || {}
     }
 
     parse(code) {
         this.contents = marked(code, this.markedOptions);
         return super.parse(this.contents);
-    }
-
-    generate() {
-        return {
-            js: `module.exports=\`${super.generate()}\``
-        };
     }
 }


### PR DESCRIPTION
In the following change to parcel bundler, the `generate` becomes async and so now returns a promise.
https://github.com/parcel-bundler/parcel/pull/1456

I believe this change is the simplest way to support the last parcel release  (`1.10.2`). `marked` generates markup that `HTMLAsset.parse()` can understand, so I believe you can rely on `HTMLAsset` to do the right thing in it's `generate()`.