### PR TITLE
Added support for renderer method overrides

### DIFF
--- a/MarkdownAsset.js
+++ b/MarkdownAsset.js
@@ -4,7 +4,8 @@ const marked = require('marked');
 module.exports = class MarkdownAsset extends HTMLAsset {
   async parse (code) {
     const pkg = await this.getPackage();
-    const config = await this.getConfig(['marked.config.js']);
+    const configPath = await this.getConfig(['marked.config.js'], { load: false });
+    const config = require(configPath); // Don't clone the config to allow for renderer overrides.
     this.markedOptions = config || pkg.marked || {};
     this.contents = marked(code, this.markedOptions);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/gongpeione/parcel-plugin-markdown"
   },
   "dependencies": {
-    "marked": "^0.4.0",
+    "marked": "^0.7.0",
     "parcel-bundler": "^1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Parcel's `getConfig` method clones the imported config object by default.
For this the [clone](https://github.com/pvorb/clone) library is used which does not copy over overridden methods in class instances.

This is relevant because of the following use-case:
```js
// marked.config.js

const marked = require("marked");
const renderer = new marked.Renderer();

// E.g. override the link method to build custom link tags:
renderer.link = function(href, title, text) {
	return `<a href="${href}" target="_blank">My link: ${text}</a>`;
}

module.exports = { renderer };
```

The cloning procedure breaks such configurations; in the example the custom `link` method would not be used. This PR fixes the problem by simply not creating a clone which afaik should not break any existing code since marked configs are static and not affected by side-effects.